### PR TITLE
fix bug for continuous Chinese punctuations

### DIFF
--- a/src/anjuke/pinyin/__init__.py
+++ b/src/anjuke/pinyin/__init__.py
@@ -50,7 +50,8 @@ class Tokenizer:
 
         while True:
             i += 1
-            if i >= self._length or self._char_type(self._text[i]) != type:
+            if i >= self._length or self._char_type(self._text[i]) != type\
+                or (self._char_type(self._text[i]) == type and type == 3):
                 break
 
         try:

--- a/src/anjuke/pinyin/__init__.py
+++ b/src/anjuke/pinyin/__init__.py
@@ -4,8 +4,8 @@ import os
 import re
 
 _punctuation_mapper = dict(zip(
-    u'？！。，、：《》“”‘’　',
-    u'?!.,,:<>""\'\' '))
+    u'·？！。，、：《》“”‘’　',
+    u'‧?!.,,:<>""\'\' '))
 
 def _load_character_mapper():
     mapper = dict()


### PR DESCRIPTION
it will raise error when there are continuous punctuations like 列夫托尔斯泰：《战争与和平》，now it's fixed
